### PR TITLE
Torrents by user

### DIFF
--- a/KickassAPI.py
+++ b/KickassAPI.py
@@ -5,7 +5,7 @@
 # Author: FEE1DE4D
 
 """
-This is an unofficial python API for kickass.to partially
+This is an unofficial python API for kickass.so partially
 inspired by https://github.com/karan/TPB
 
 by FEE1DE4D (fee1de4d@gmail.com)
@@ -21,8 +21,8 @@ from collections import namedtuple
 
 # CONSTANTS
 class BASE(object):
-    SEARCH = "http://www.kickass.to/usearch/"
-    LATEST = "http://www.kickass.to/new/"
+    SEARCH = "http://www.kickass.so/usearch/"
+    LATEST = "http://www.kickass.so/new/"
 
 class CATEGORY(object):
     MOVIES = "movies"
@@ -202,7 +202,7 @@ class Results(object):
         category = td("span").find("strong").find("a").eq(0).text()
         verified_torrent = True if td("a.iverify.icon16") else False
         comments = td("a.icomment.icommentjs.icon16").text()
-        torrent_link = "http://www.kickass.to"
+        torrent_link = "http://www.kickass.so"
         if td("a.cellMainLink").attr("href") is not None:
             torrent_link += td("a.cellMainLink").attr("href")
         magnet_link = td("a.imagnet.icon16").attr("href")
@@ -313,7 +313,7 @@ class Results(object):
 
 class Latest(Results):
     """
-    Results subclass that represents http://kickass.to/new/
+    Results subclass that represents http://kickass.so/new/
     """
     def __init__(self, page=1, order=None):
         self.url = LatestUrl(page, order)
@@ -322,7 +322,7 @@ class Latest(Results):
 
 class Search(Results):
     """
-    Results subclass that represents http://kickass.to/usearch/
+    Results subclass that represents http://kickass.so/usearch/
     """
     def __init__(self, query, page=1, category=None, order=None):
         self.url = SearchUrl(query, page, category, order)

--- a/KickassAPI.py
+++ b/KickassAPI.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Version: 2.7
+# Version: 2.8
 # Author: FEE1DE4D
 
 """
@@ -26,6 +26,7 @@ from collections import namedtuple
 class BASE(object):
     SEARCH = "http://www.kickass.so/usearch/"
     LATEST = "http://www.kickass.so/new/"
+    USER = "http://www.kickass.so/user/"
 
 class CATEGORY(object):
     MOVIES = "movies"
@@ -173,6 +174,34 @@ class SearchUrl(Url):
             order = ""
 
         ret = "".join((self.base, self.query, category, page, order))
+
+        if update:
+            self.max_page = self._get_max_page(ret)
+        return ret
+
+
+
+class UserUrl(Url):
+
+    def __init__(self, user, page, order):
+        self.base = BASE.USER
+        self.user = user
+        self.page = page
+        self.order = order
+        self.max_page = None
+        self.build()
+
+    def build(self, update=True):
+        """
+        Build and return url. Also update max_page.
+        URL structure for user torrent lists differs from other result lists
+        as the page number is part of the query string and not the URL path
+        """
+        query_str = "?page={}".format(self.page)
+        if self.order:
+            query_str += "".join(("&field=", self.order[0], "&sorder=",self.order[1]))
+
+        ret = "".join((self.base, self.user, "/uploads/", query_str))
 
         if update:
             self.max_page = self._get_max_page(ret)
@@ -335,6 +364,15 @@ class Latest(Results):
     """
     def __init__(self, page=1, order=None):
         self.url = LatestUrl(page, order)
+
+
+
+class User(Results):
+    """
+    Results subclass that represents http://kickass.so/user/
+    """
+    def __init__(self, user, page=1, order=None):
+        self.url = UserUrl(user, page, order)
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 KickassAPI
 ==========
-This is an unofficial python API for kickass.to partially inspired by https://github.com/karan/TPB
+This is an unofficial python API for kickass.so partially inspired by https://github.com/karan/TPB
 
 Installation
 -----------
@@ -12,7 +12,7 @@ pip install KickassAPI
 Usage
 -----
 
-```Search``` represents ```http://kickass.to/usearch/``` and ```Latest``` ```http://kickass.to/new/```  
+```Search``` represents ```http://kickass.so/usearch/``` and ```Latest``` ```http://kickass.so/new/```
 
 ```python
 from KickassAPI import Search, Latest, CATEGORY, ORDER

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ pip install KickassAPI
 Usage
 -----
 
-```Search``` represents ```http://kickass.so/usearch/``` and ```Latest``` ```http://kickass.so/new/```
+```Search``` represents ```http://kickass.so/usearch/```, ```Latest``` ```http://kickass.so/new/```, and ```User``` ```http://kickass.so/user/username/uploads/```
 
 ```python
-from KickassAPI import Search, Latest, CATEGORY, ORDER
+from KickassAPI import Search, Latest, User, CATEGORY, ORDER
 
 #Print the basic info about first 25 results of "Game of thrones" search
 for t in Search("Game of thrones"):
@@ -45,6 +45,10 @@ Search("Game of thrones").category(CATEGORY.GAMES).order(ORDER.FILES_COUNT).next
 for t in Latest().order(ORDER.SEED):
     t.lookup()
 
+#User also has the same behaviour as Search, and also lacks the ```category()``` method, but takes a username in place of a query string
+for t in User('reduxionist'):
+    t.lookup()
+
 #Page, order and category can be also specified in constructor
 Search("Game of thrones", category=CATEGORY.GAMES, order=ORDER.AGE, page=5)
 
@@ -59,6 +63,6 @@ for t in Latest().all():
 #Get list of torrent objects instead of iterator
 Latest().list()
 
-#pages(), all() and list() cant be followed by any other method!
+#pages(), all() and list() can't be followed by any other method!
 
 ```

--- a/tests.py
+++ b/tests.py
@@ -39,22 +39,22 @@ class TestURL:
 
     def test_latest_build(self):
         latest = KickassAPI.LatestUrl(1, None)
-        res = "http://www.kickass.to/new/1/"
+        res = "http://www.kickass.so/new/1/"
         assert latest.build(update=False) == res
 
         latest2 = KickassAPI.LatestUrl(1, (KickassAPI.ORDER.AGE,
                                            KickassAPI.ORDER.ASC))
-        res2 = "http://www.kickass.to/new/1/?field=time_add&sorder=asc"
+        res2 = "http://www.kickass.so/new/1/?field=time_add&sorder=asc"
         assert latest2.build(update=False) == res2
 
     def test_search_build(self):
         search = KickassAPI.SearchUrl("test", 1, None, None)
-        res = "http://www.kickass.to/usearch/test/1/"
+        res = "http://www.kickass.so/usearch/test/1/"
         assert search.build(update=False) == res
 
         search2 = KickassAPI.SearchUrl("test", 1, KickassAPI.CATEGORY.GAMES,
                             (KickassAPI.ORDER.SIZE, KickassAPI.ORDER.DESC))
-        res2 = ("http://www.kickass.to/usearch/test category:games/1/"
+        res2 = ("http://www.kickass.so/usearch/test category:games/1/"
                "?field=size&sorder=desc")
         assert search2.build(update=False) == res2
 

--- a/tests.py
+++ b/tests.py
@@ -6,7 +6,7 @@ This submodule uses pytest framework: http://pytest.org
 """
 class TestURL:
     """
-    Url, LatestUrl and SearchUrl tests
+    Url, LatestUrl, UserUrl, and SearchUrl tests
     """
     def setup_method(self, method):
         self.url = KickassAPI.Url()
@@ -58,4 +58,14 @@ class TestURL:
                "?field=size&sorder=desc")
         assert search2.build(update=False) == res2
 
+    def test_user_build(self):
+        user = KickassAPI.UserUrl("reduxionist", 1, None)
+        res = "http://www.kickass.so/user/reduxionist/uploads/?page=1"
+        assert user.build(update=False) == res
+
+        user2 = KickassAPI.UserUrl("reduxionist", 1, (KickassAPI.ORDER.SIZE,
+                                                      KickassAPI.ORDER.DESC))
+        res2 = ("http://www.kickass.so/user/reduxionist/uploads/"
+               "?page=1&field=size&sorder=desc")
+        assert user2.build(update=False) == res2
 


### PR DESCRIPTION
This pull request adds a User class that permits querying by Kickass username, and supports the same API methods as Latest. Tests and documentation updates are included.

To support querying kickass by user, it was necessary to make calls to PyQuery able to handle gzipped content because the user results response is returned compressed regardless of the accept-encoding headers sent with the request.

This pull request also updates the kickass.to domain to kickass.so (see https://torrentfreak.com/kickasstorrents-moves-kickass-so-domain-name-141117/), and bumps the minor version number for your convenience.

Thanks for the API!