### PR TITLE
Add torrents-by-user functionality and tests

### DIFF
--- a/KickassAPI.py
+++ b/KickassAPI.py
@@ -23,6 +23,7 @@ import requests
 class BASE(object):
     SEARCH = "http://www.kickass.to/usearch/"
     LATEST = "http://www.kickass.to/new/"
+    USER = "http://www.kickass.to/user/"
 
 
 class CATEGORY(object):
@@ -156,6 +157,33 @@ class SearchUrl(Url):
             order = ""
 
         ret = "".join((self.base, self.query, category, page, order))
+
+        if update:
+            self.max_page = self._get_max_page(ret)
+        return ret
+
+
+class UserUrl(Url):
+
+    def __init__(self, user, page, order):
+        self.base = BASE.USER
+        self.user = user
+        self.page = page
+        self.order = order
+        self.max_page = None
+        self.build()
+
+    def build(self, update=True):
+        """
+        Build and return url. Also update max_page.
+        URL structure for user torrent lists differs from other result lists
+        as the page number is part of the query string and not the URL path
+        """
+        query_str = "?page={}".format(self.page)
+        if self.order:
+            query_str += "".join(("&field=", self.order[0], "&sorder=",self.order[1]))
+
+        ret = "".join((self.base, self.user, "/uploads/", query_str))
 
         if update:
             self.max_page = self._get_max_page(ret)
@@ -311,6 +339,14 @@ class Latest(Results):
     """
     def __init__(self, page=1, order=None):
         self.url = LatestUrl(page, order)
+
+
+class User(Results):
+    """
+    Results subclass that represents http://kickass.to/user/
+    """
+    def __init__(self, user, page=1, order=None):
+        self.url = UserUrl(user, page, order)
 
 
 class Search(Results):

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ pip install KickassAPI
 Usage
 -----
 
-```Search``` represents ```http://kickass.to/usearch/``` and ```Latest``` ```http://kickass.to/new/```  
+```Search``` represents ```http://kickass.to/usearch/```, ```Latest``` ```http://kickass.to/new/```, and ```User``` ```http://kickass.to/user/username/uploads/```
 
 ```python
-from KickassAPI import Search, Latest, CATEGORY, ORDER
+from KickassAPI import Search, Latest, User, CATEGORY, ORDER
 
 #Print the basic info about first 25 results of "Game of thrones" search
 for t in Search("Game of thrones"):
@@ -45,6 +45,10 @@ Search("Game of thrones").category(CATEGORY.GAMES).order(ORDER.FILES_COUNT).next
 for t in Latest().order(ORDER.SEED):
     t.lookup()
 
+#User also has the same behaviour as Search, and also lacks the ```category()``` method, but takes a username in place of a query string
+for t in User('reduxionist'):
+    t.lookup()
+
 #Page, order and category can be also specified in constructor
 Search("Game of thrones", category=CATEGORY.GAMES, order=ORDER.AGE, page=5)
 
@@ -59,6 +63,6 @@ for t in Latest().all():
 #Get list of torrent objects instead of iterator
 Latest().list()
 
-#pages(), all() and list() cant be followed by any other method!
+#pages(), all() and list() can't be followed by any other method!
 
 ```

--- a/tests.py
+++ b/tests.py
@@ -6,7 +6,7 @@ This submodule uses pytest framework: http://pytest.org
 """
 class TestURL:
     """
-    Url, LatestUrl and SearchUrl tests
+    Url, LatestUrl, UserUrl, and SearchUrl tests
     """
     def setup_method(self, method):
         self.url = KickassAPI.Url()
@@ -58,4 +58,14 @@ class TestURL:
                "?field=size&sorder=desc")
         assert search2.build(update=False) == res2
 
+    def test_user_build(self):
+        user = KickassAPI.UserUrl("reduxionist", 1, None)
+        res = "http://www.kickass.to/user/reduxionist/uploads/?page=1"
+        assert user.build(update=False) == res
+
+        user2 = KickassAPI.UserUrl("reduxionist", 1, (KickassAPI.ORDER.SIZE,
+                                                      KickassAPI.ORDER.DESC))
+        res2 = ("http://www.kickass.to/user/reduxionist/uploads/"
+               "?page=1&field=size&sorder=desc")
+        assert user2.build(update=False) == res2
 


### PR DESCRIPTION
Per your response to my previous pull-request, here is just the torrents by user functionality. Don't hesitate to let me know if any tweaks are required.

As you observed, since the time of my original PR they reverted back to the .to TLD (the .so TLD was taken from them against their will AFAIK), and using requests is indeed a cleaner solution to handling gzipped content -- I just didn't want to introduce any dependencies to someone else's library (though I now realize that pyquery already depended on requests, but since you weren't importing it yourself it didn't come to my attention at the time).

Thanks!