### PR TITLE
when getting results, bail out with an empty array if search came up emp...

### DIFF
--- a/KickassAPI.py
+++ b/KickassAPI.py
@@ -17,6 +17,7 @@ from pyquery import PyQuery
 import threading
 from collections import namedtuple
 import requests
+import re
 
 
 # CONSTANTS
@@ -252,6 +253,8 @@ class Results(object):
         Return all rows on page
         """
         html = requests.get(self.url.build()).text
+        if re.search('did not match any documents', html):
+            return []
         pq = PyQuery(html)
         rows = pq("table.data").find("tr")
         return map(rows.eq, range(rows.size()))[1:]


### PR DESCRIPTION
Hello!  I noticed when performing searches with search strings that return NO results, KAT falls back to a search string that DOES have results, and KickassAPI is currently unable to tell the difference.

For example, a search for "Seinfeld S29E01" will cause KAT to fall back to "Seinfeld" as the search string, and return those results.

In this PR, I'm proposing we search for ''did not match any documents" in the HTML content, and if it's found, simply ignore the table data and return an empty array.

Unfortunately the HTTP Response Status Code or headers don't seem to change whether or not the initial search string passes or fails, so I don't think there's a more elegant solution to this issue :/