### PR TITLE
Update tests and docs for domain change to kat.cr

### DIFF
--- a/KickassAPI.py
+++ b/KickassAPI.py
@@ -5,7 +5,7 @@
 # Author: FEE1DE4D
 
 """
-This is an unofficial python API for kickass.to partially
+This is an unofficial python API for kat.cr (formerly kickass.to) partially
 inspired by https://github.com/karan/TPB
 
 by FEE1DE4D (fee1de4d@gmail.com)
@@ -231,7 +231,7 @@ class Results(object):
         category = td("span").find("strong").find("a").eq(0).text()
         verified_torrent = True if td("a.iverify.icon16") else False
         comments = td("a.icomment.icommentjs.icon16").text()
-        torrent_link = "http://www.kickass.to"
+        torrent_link = "http://" + BASE.domain
         if td("a.cellMainLink").attr("href") is not None:
             torrent_link += td("a.cellMainLink").attr("href")
         magnet_link = td("a.imagnet.icon16").attr("href")
@@ -338,7 +338,7 @@ class Results(object):
 
 class Latest(Results):
     """
-    Results subclass that represents http://kickass.to/new/
+    Results subclass that represents http://kat.cr/new/
     """
     def __init__(self, page=1, order=None):
         self.url = LatestUrl(page, order)
@@ -346,7 +346,7 @@ class Latest(Results):
 
 class User(Results):
     """
-    Results subclass that represents http://kickass.to/user/
+    Results subclass that represents http://kat.cr/user/
     """
     def __init__(self, user, page=1, order=None):
         self.url = UserUrl(user, page, order)
@@ -354,7 +354,7 @@ class User(Results):
 
 class Search(Results):
     """
-    Results subclass that represents http://kickass.to/usearch/
+    Results subclass that represents http://kat.cr/usearch/
     """
     def __init__(self, query, page=1, category=None, order=None):
         self.url = SearchUrl(query, page, category, order)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 KickassAPI
 ==========
-This is an unofficial python API for kickass.to partially inspired by https://github.com/karan/TPB
+This is an unofficial python API for kat.cr (formerly kickass.to) partially inspired by https://github.com/karan/TPB
 
 Installation
 -----------
@@ -12,7 +12,7 @@ pip install KickassAPI
 Usage
 -----
 
-```Search``` represents ```http://kickass.to/usearch/```, ```Latest``` ```http://kickass.to/new/```, and ```User``` ```http://kickass.to/user/username/uploads/```
+```Search``` represents ```http://kat.cr/usearch/```, ```Latest``` ```http://kat.cr/new/```, and ```User``` ```http://kat.cr/user/username/uploads/```
 
 ```python
 from KickassAPI import Search, Latest, User, CATEGORY, ORDER

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,11 @@ setup(
     author_email='m@fm4d.net',
 
     url=URL,
-    description='Python API for kickass.to',
+    description='Python API for kat.cr (formerly kickass.to)',
     license='GPLv2+',
 
     long_description="Documentation can be found here " + URL,
-    
+
      install_requires=[
         'setuptools',
         'pyquery',

--- a/tests.py
+++ b/tests.py
@@ -1,6 +1,8 @@
 import KickassAPI
 import pytest
 
+BASE_URL = "http://" + KickassAPI.BASE.domain
+
 """
 This submodule uses pytest framework: http://pytest.org
 """
@@ -39,33 +41,33 @@ class TestURL:
 
     def test_latest_build(self):
         latest = KickassAPI.LatestUrl(1, None)
-        res = "http://www.kickass.to/new/1/"
+        res = BASE_URL + "/new/1/"
         assert latest.build(update=False) == res
 
         latest2 = KickassAPI.LatestUrl(1, (KickassAPI.ORDER.AGE,
                                            KickassAPI.ORDER.ASC))
-        res2 = "http://www.kickass.to/new/1/?field=time_add&sorder=asc"
+        res2 = BASE_URL + "/new/1/?field=time_add&sorder=asc"
         assert latest2.build(update=False) == res2
 
     def test_search_build(self):
         search = KickassAPI.SearchUrl("test", 1, None, None)
-        res = "http://www.kickass.to/usearch/test/1/"
+        res = BASE_URL + "/usearch/test/1/"
         assert search.build(update=False) == res
 
         search2 = KickassAPI.SearchUrl("test", 1, KickassAPI.CATEGORY.GAMES,
                             (KickassAPI.ORDER.SIZE, KickassAPI.ORDER.DESC))
-        res2 = ("http://www.kickass.to/usearch/test category:games/1/"
+        res2 = (BASE_URL + "/usearch/test category:games/1/"
                "?field=size&sorder=desc")
         assert search2.build(update=False) == res2
 
     def test_user_build(self):
         user = KickassAPI.UserUrl("reduxionist", 1, None)
-        res = "http://www.kickass.to/user/reduxionist/uploads/?page=1"
+        res = BASE_URL + "/user/reduxionist/uploads/?page=1"
         assert user.build(update=False) == res
 
         user2 = KickassAPI.UserUrl("reduxionist", 1, (KickassAPI.ORDER.SIZE,
                                                       KickassAPI.ORDER.DESC))
-        res2 = ("http://www.kickass.to/user/reduxionist/uploads/"
+        res2 = (BASE_URL + "/user/reduxionist/uploads/"
                "?page=1&field=size&sorder=desc")
         assert user2.build(update=False) == res2
 


### PR DESCRIPTION
Tests were failing and docs were slightly inaccurate subsequent to PR #11, so I adjusted the tests to make use of the new BASE.domain constant and updated the docs accordingly. There was also one remaining use of a hard-coded kickass.to in Results._get_torrent.torrent_link so I updated that too.